### PR TITLE
Customizable color samples

### DIFF
--- a/css/demo.css
+++ b/css/demo.css
@@ -17,12 +17,12 @@
     padding: 0 0.3em;
 }
 
-.legend .chip {
+.legend .color-sample {
     display: block;
     float: left;
     width: 1em;
     height: 1em;
-    border: 2px solid;
-    border-radius: 0.5em;
+    border: 2px solid; /* Comment out if you don't want to show the fillColor */
+    border-radius: 0.5em; /* Comment out if you prefer squarish samples */
     margin-right: 0.5em;
 }

--- a/src/legend.js
+++ b/src/legend.js
@@ -12,11 +12,11 @@ function legend(parent, data) {
         title.className = 'title';
         parent.appendChild(title);
 
-        var chip = document.createElement('div');
-        chip.className = 'chip';
-        chip.style.backgroundColor = d.hasOwnProperty('strokeColor') ? d.strokeColor : d.color;
-        chip.style.borderColor = d.hasOwnProperty('fillColor') ? d.fillColor : d.color;
-        title.appendChild(chip);
+        var colorSample = document.createElement('div');
+        colorSample.className = 'color-sample';
+        colorSample.style.backgroundColor = d.hasOwnProperty('strokeColor') ? d.strokeColor : d.color;
+        colorSample.style.borderColor = d.hasOwnProperty('fillColor') ? d.fillColor : d.color;
+        title.appendChild(colorSample);
 
         var text = document.createTextNode(d.label);
         title.appendChild(text);


### PR DESCRIPTION
Instead of using a left border to show the corresponding color sample, use a `div` element.  This will allow everyone to shape it easily using CSS, leaving the JS logic alone.

The default shape is now a circle filled with `strokeColor` and bordered with the `fillColor`.  It could make more sense to use colors the other way around, but I think it's easier to read this way.

Added a few comments to `demo.css` to explain how to switch from circles to squares.
